### PR TITLE
Introduce ScreenPane as the structural root of the component tree

### DIFF
--- a/lib/ttyui/component.rb
+++ b/lib/ttyui/component.rb
@@ -136,11 +136,8 @@ class Component
   def on_focus; end
 
   # @return [Boolean] true if this component's tree is currently mounted on the
-  # {Screen} as either the main content or a popup.
-  def attached?
-    r = root
-    screen.content == r || screen.popups.include?(r)
-  end
+  # {Screen}, i.e. its root is the {ScreenPane}.
+  def attached? = root == screen.pane
 
   # Called by container components after `child` has been detached from
   # `self.children` (its `parent` is already nil and it is no longer in the

--- a/lib/ttyui/screen.rb
+++ b/lib/ttyui/screen.rb
@@ -5,6 +5,7 @@ require_relative 'popup_window'
 require_relative 'event_queue'
 require_relative 'component'
 require_relative 'layout'
+require_relative 'screen_pane'
 require 'io/console'
 require 'tty-cursor'
 require 'tty-screen'
@@ -31,9 +32,6 @@ class Screen
     @@instance = self
     # {EventQueue} Event queue
     @event_queue = EventQueue.new
-    # {Array<Window>} modal popup windows, listed in order as they were opened.
-    # Last popup is the topmost one and receives all key events.
-    @popups = []
     @size = EventQueue::TTYSizeEvent.create
     # {Set<Component>} invalidated components (need repaint)
     @invalidated = Set.new
@@ -43,9 +41,12 @@ class Screen
     # Until the event loop is run, we pretend we're in the UI thread.
     # This allows AppScreen to initialize.
     @pretend_ui_lock = true
-    # Bottom status bar
-    @status_bar = Component::Label.new
+    # Structural root of the component tree: holds tiled content, popup stack and status bar.
+    @pane = ScreenPane.new
   end
+
+  # @return [ScreenPane] the structural root of the component tree.
+  attr_reader :pane
 
   # @return [Screen] the singleton instance
   def self.instance
@@ -54,21 +55,19 @@ class Screen
     @@instance
   end
 
-  # @return [Component | nil]
-  attr_reader :content
+  # @return [Component | nil] tiled content (forwarded to {ScreenPane}).
+  def content = @pane.content
 
   def content=(content)
-    raise unless content.is_a? Component
-
-    self.focused = nil
-    @content = content
+    @pane.content = content
     layout
   end
 
   # Provides access to {:width} and {:height} of the screen.
   attr_reader :size
-  # @return [Array<Window>] currently active popup windows. The array must not be modified!
-  attr_reader :popups
+  # @return [Array<Window>] currently active popup windows (forwarded to {ScreenPane}).
+  # The array must not be modified!
+  def popups = @pane.popups
   # @return [EventQueue] the event queue
   attr_reader :event_queue
 
@@ -95,47 +94,36 @@ class Screen
   attr_reader :focused
 
   # Sets the focused {Component}. Focused component receives keyboard events.
+  # All focusable components live under {#pane}, so this is a single uniform
+  # path (no separate popup-vs-content branches).
   # @param focused [Component | nil] the new component to be focused.
   def focused=(focused)
     raise unless focused.nil? || focused.is_a?(Component)
 
     check_locked
-    if @popups.include?(focused)
-      @focused = focused
-      focused.on_tree { it.active = true if it.can_activate? }
-      focused.on_focus
-      return
-    elsif @popups.include?(focused&.root)
-      @focused = focused
-      focused.active = true
-      return
-    end
-
     if focused.nil?
       @focused = nil
-      @content&.on_tree { it.active = false }
+      @pane.on_tree { it.active = false if it.can_activate? }
     else
-      root = focused.root
-      raise if root != @content || @popups.include?(root)
+      raise if focused.root != @pane
 
       @focused = focused
-      active = [focused]
-      active << active.last.parent until active.last.parent.nil?
-      active = active.to_set
-      @content.on_tree { it.active = active.include?(it) if it.can_activate? }
+      active = Set[focused]
+      cursor = focused.parent
+      until cursor.nil?
+        active << cursor
+        cursor = cursor.parent
+      end
+      @pane.on_tree { it.active = active.include?(it) if it.can_activate? }
       @focused.on_focus
     end
-    @status_bar.text = "q #{Rainbow('quit').cadetblue}  #{active_window&.keyboard_hint}".strip
+    @pane.status_bar.text = "q #{Rainbow('quit').cadetblue}  #{active_window&.keyboard_hint}".strip
   end
 
   # @param window [PopupWindow] the popup to add. Will be centered and painted automatically.
   def add_popup(window)
-    raise unless window.is_a? PopupWindow
-
-    @popups << window
-    window.center
-    self.focused = window
-    invalidate(window)
+    check_locked
+    @pane.add_popup(window)
     # no need to fully repaint the scene: PopupWindow simply paints over current screen contents.
   end
 
@@ -158,26 +146,24 @@ class Screen
   def active_window
     check_locked
     result = nil
-    @content&.on_tree { result = it if it.is_a?(Window) && it.active? }
+    @pane.content&.on_tree { result = it if it.is_a?(Window) && it.active? }
     result
   end
 
   # Removes a popup. Repaints the whole scene, which should visually "remove" the window. The window will also no longer
-  # receive keys.
+  # receive keys. Focus repair is handled by {ScreenPane#on_child_removed}.
   #
   # Does nothing if the window is not open on this screen.
   def remove_popup(window)
     check_locked
-    raise 'window is not a popup' unless @popups.delete(window)
-
-    self.focused = @popups.last || @content if @focused && @focused.root == window
+    @pane.remove_popup(window)
     needs_full_repaint
   end
 
   # @return [Boolean] if screen contains this window.
   def has_popup?(window)
     check_locked
-    @popups.include?(window)
+    @pane.has_popup?(window)
   end
 
   # Testing only - creates new screen, locks the UI, and prevents any redraws,
@@ -190,7 +176,7 @@ class Screen
 
   def close
     clear
-    @content = nil
+    @pane = nil
     @@instance = nil
   end
 
@@ -218,15 +204,16 @@ class Screen
     did_paint = false
     until @invalidated.empty?
       did_paint = true
-      # Figure out repaint order of @content first.
-      repaint = @invalidated.to_a.delete_if { @popups.include? it }
+      popups = @pane.popups
+      # Figure out repaint order of tiled components first.
+      repaint = @invalidated.to_a.delete_if { popups.include? it }
       # Repaint parents before children, so that
       # children won't paint over parents.
       repaint.sort_by!(&:depth)
 
-      # If some @content needs repaint, it may draw over popups.
+      # If some tiled component needs repaint, it may draw over popups.
       # In such case repaint all popups.
-      repaint += repaint.empty? ? @popups.filter { @invalidated.include? it } : @popups
+      repaint += repaint.empty? ? popups.filter { @invalidated.include? it } : popups
       @repainting = repaint.to_set
       @invalidated.clear
 
@@ -263,40 +250,24 @@ class Screen
   def layout
     check_locked
     needs_full_repaint
-    @content.rect = Rect.new(0, 0, size.width, size.height - 1)
-    @popups.each(&:center)
-    @status_bar.rect = Rect.new(0, size.height - 1, size.width, 1)
+    @pane.rect = Rect.new(0, 0, size.width, size.height)
     repaint
   end
 
   # Called after a popup is closed. Since a popup can cover any window, top-level component
   # or other popups, we need to redraw everything.
   def needs_full_repaint
-    @content&.on_tree { invalidate it }
-    @popups.each { invalidate it }
-    invalidate @status_bar
+    @pane&.on_tree { invalidate it }
   end
 
   # A key has been pressed on the keyboard. Handle it, or forward to active window.
   # @param [String] key
   # @return [Boolean] true if the key was handled by some window.
-  def handle_key(key)
-    topmost_popup = @popups.last
-    return topmost_popup.handle_key(key) unless topmost_popup.nil?
-    return @content.handle_key(key) unless @content.nil?
-
-    false
-  end
+  def handle_key(key) = @pane.handle_key(key)
 
   # Finds target window and calls {Window.handle_mouse}
   # @param event [MouseEvent]
-  def handle_mouse(event)
-    x = event.x - 1
-    y = event.y - 1
-    clicked = @popups.rfind { it.rect.contains?(x, y) }
-    clicked = @content if clicked.nil? && @popups.empty?
-    clicked&.handle_mouse(event)
-  end
+  def handle_mouse(event) = @pane.handle_mouse(event)
 
   def event_loop
     @event_queue.run_loop do |event|

--- a/lib/ttyui/screen.rb
+++ b/lib/ttyui/screen.rb
@@ -205,15 +205,28 @@ class Screen
     until @invalidated.empty?
       did_paint = true
       popups = @pane.popups
-      # Figure out repaint order of tiled components first.
-      repaint = @invalidated.to_a.delete_if { popups.include? it }
-      # Repaint parents before children, so that
-      # children won't paint over parents.
-      repaint.sort_by!(&:depth)
 
-      # If some tiled component needs repaint, it may draw over popups.
-      # In such case repaint all popups.
-      repaint += repaint.empty? ? popups.filter { @invalidated.include? it } : popups
+      # Partition invalidated components into tiled vs popup-tree. Sorting by
+      # depth across the whole tree would interleave them: a tiled grandchild
+      # (depth 3) sorts after a popup's content (depth 2) and overdraws it.
+      popup_tree = Set.new
+      popups.each { |p| p.on_tree { popup_tree << it } }
+      tiled, popup_invalidated = @invalidated.to_a.partition { !popup_tree.include?(it) }
+
+      # Within the tiled tree, paint parents before children.
+      tiled.sort_by!(&:depth)
+
+      repaint = if tiled.empty?
+                  # Only popups need repaint — paint just their invalidated
+                  # components in depth order.
+                  popup_invalidated.sort_by(&:depth)
+                else
+                  # Tiled components may overdraw popups; repaint each open
+                  # popup's full subtree on top, in stacking order
+                  # (parent-before-child within each popup).
+                  tiled + popups.flat_map { |p| collect_subtree(p) }
+                end
+
       @repainting = repaint.to_set
       @invalidated.clear
 
@@ -234,6 +247,14 @@ class Screen
   def cursor_position = @focused&.cursor_position
 
   private
+
+  # Collects a component and all its descendants in tree order
+  # (parent before children).
+  def collect_subtree(component)
+    result = []
+    component.on_tree { result << it }
+    result
+  end
 
   # Hides or moves the hardware cursor based on the current focus state.
   def position_cursor

--- a/lib/ttyui/screen_pane.rb
+++ b/lib/ttyui/screen_pane.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative 'component'
+
+# The structural root of the {Screen}'s component tree.
+#
+# {Screen} is a singleton runtime owner (event loop, lock, terminal IO,
+# invalidation set). All actual UI lives under a {ScreenPane}: the tiled
+# {#content}, the modal {#popups} stack, and the bottom {#status_bar}.
+# Putting them under a single Component parent gives focus traversal a real
+# root, makes {Component#attached?} a one-liner, and lets popup-focus repair
+# fall out of the standard {Component#on_child_removed} hook.
+#
+# The pane is not a {Component::Layout}: popups deliberately overlap content
+# (Z-ordered, full overdraw, no clipping) and key/mouse dispatch follows
+# modal-popup rules rather than active-child dispatch.
+class ScreenPane < Component
+  def initialize
+    super
+    @popups = []
+    @status_bar = Component::Label.new
+    @status_bar.parent = self
+  end
+
+  # @return [Component | nil] the tiled content component.
+  attr_reader :content
+  # @return [Array<PopupWindow>] modal popup windows in stacking order; last is topmost.
+  # The array must not be mutated by callers.
+  attr_reader :popups
+  # @return [Component::Label] the bottom status bar.
+  attr_reader :status_bar
+
+  def can_activate? = false
+
+  # Children for tree traversal: content first, popups in stacking order, status bar last.
+  def children = [*[@content].compact, *@popups, @status_bar]
+
+  # Replaces the tiled content. Wipes focus first (the new tree starts fresh),
+  # detaches the old content, then attaches the new one and re-lays out.
+  # @param content [Component]
+  def content=(content)
+    raise unless content.is_a? Component
+    raise if !content.parent.nil?
+    return if @content == content
+
+    screen.focused = nil
+    old = @content
+    old&.parent = nil
+    @content = content
+    content.parent = self
+    layout
+  end
+
+  # Adds a popup, centers it, focuses it, and invalidates it for repaint.
+  # @param window [PopupWindow]
+  def add_popup(window)
+    raise unless window.is_a? PopupWindow
+    raise if !window.parent.nil?
+
+    @popups << window
+    window.parent = self
+    window.center
+    screen.focused = window
+    screen.invalidate(window)
+  end
+
+  # Removes a popup. If the popup held focus, focus shifts to the now-topmost
+  # remaining popup, falling back to {#content}, then to nil.
+  # @param window [PopupWindow]
+  def remove_popup(window)
+    raise 'window is not a popup' unless @popups.delete(window)
+
+    window.parent = nil
+    on_child_removed(window)
+  end
+
+  # @return [Boolean] true if this pane currently hosts the popup.
+  def has_popup?(window) = @popups.include?(window)
+
+  # Re-lays out children whenever the pane's own rect changes (width or height).
+  def rect=(new_rect)
+    super
+    layout
+  end
+
+  # Lays out content (full pane minus the bottom row) and the status bar (bottom row).
+  # Popups self-position via {PopupWindow#center}.
+  def layout
+    return if rect.empty?
+
+    @content.rect = Rect.new(rect.left, rect.top, rect.width, [rect.height - 1, 0].max) unless @content.nil?
+    @popups.each(&:center)
+    @status_bar.rect = Rect.new(rect.left, rect.top + rect.height - 1, rect.width, 1)
+  end
+
+  # Pane paints nothing itself; its children paint over the entire rect.
+  def repaint; end
+
+  # Topmost popup is modal: it eats keys. Falls through to content only when
+  # no popup is open.
+  def handle_key(key)
+    topmost = @popups.last
+    return topmost.handle_key(key) unless topmost.nil?
+    return @content.handle_key(key) unless @content.nil?
+
+    false
+  end
+
+  # Mouse events check popups in reverse stacking order (topmost first), and
+  # fall through to content only when no popup is hit *and* there are no popups
+  # open. This preserves modal click-blocking: an open popup eats clicks even
+  # outside its rect.
+  def handle_mouse(event)
+    x = event.x - 1
+    y = event.y - 1
+    clicked = @popups.rfind { it.rect.contains?(x, y) }
+    clicked = @content if clicked.nil? && @popups.empty?
+    clicked&.handle_mouse(event)
+  end
+
+  # Focus repair when a child detaches. Default Component#on_child_removed
+  # would refocus to `self` (the pane), which isn't a useful focus target.
+  # Instead, route focus to the now-topmost popup, then to content, then nil.
+  def on_child_removed(child)
+    return unless attached?
+
+    f = screen.focused
+    return if f.nil?
+
+    cursor = f
+    while cursor
+      if cursor == child
+        screen.focused = @popups.last || @content
+        return
+      end
+      cursor = cursor.parent
+    end
+  end
+
+end

--- a/spec/ttyui/list_spec.rb
+++ b/spec/ttyui/list_spec.rb
@@ -326,12 +326,18 @@ describe Component::List do
       assert_equal 0, l.top_line
     end
 
+    def attach_as_content(component)
+      pane = Screen.instance.pane
+      pane.instance_variable_set(:@content, component)
+      component.send(:parent=, pane)
+    end
+
     it 'moves cursor on left click within rect' do
       l = Component::List.new
       l.rect = Rect.new(0, 0, 20, 5)
       l.content = (0..9).map(&:to_s)
       l.cursor = Component::List::Cursor.new
-      Screen.instance.instance_variable_set(:@content, l)
+      attach_as_content(l)
       # rect is 0,0 so event.y - 1 = 0-based row; click on row 2 (event.y=3)
       l.handle_mouse(MouseEvent.new(:left, 5, 3))
       assert_equal 2, l.cursor.position
@@ -342,7 +348,7 @@ describe Component::List do
       l.rect = Rect.new(5, 5, 10, 5)
       l.content = (0..9).map(&:to_s)
       l.cursor = Component::List::Cursor.new
-      Screen.instance.instance_variable_set(:@content, l)
+      attach_as_content(l)
       l.handle_mouse(MouseEvent.new(:left, 1, 1))
       assert_equal 0, l.cursor.position
     end

--- a/spec/ttyui/screen_pane_spec.rb
+++ b/spec/ttyui/screen_pane_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'ttyui/screen'
+require 'ttyui/popup_window'
+
+describe ScreenPane do
+  before { Screen.fake }
+  after { Screen.close }
+  let(:pane) { Screen.instance.pane }
+
+  it 'is the root of the component tree' do
+    assert_nil pane.parent
+    assert_equal pane, pane.root
+  end
+
+  it 'reports itself as attached to the screen' do
+    assert pane.attached?
+  end
+
+  it 'owns the status bar and parents it' do
+    assert_instance_of Component::Label, pane.status_bar
+    assert_equal pane, pane.status_bar.parent
+  end
+
+  it 'is exposed via Screen#pane' do
+    assert_equal pane, Screen.instance.pane
+  end
+
+  context 'rect propagation' do
+    it 'lays out content and status bar when its rect is set' do
+      layout = Component::Layout::Absolute.new
+      Screen.instance.content = layout
+      pane.rect = Rect.new(0, 0, 80, 24)
+      assert_equal Rect.new(0, 0, 80, 23), layout.rect
+      assert_equal Rect.new(0, 23, 80, 1), pane.status_bar.rect
+    end
+
+    it 'relayouts on a height-only change' do
+      layout = Component::Layout::Absolute.new
+      Screen.instance.content = layout
+      pane.rect = Rect.new(0, 0, 80, 24)
+      pane.rect = Rect.new(0, 0, 80, 30)
+      assert_equal Rect.new(0, 0, 80, 29), layout.rect
+      assert_equal Rect.new(0, 29, 80, 1), pane.status_bar.rect
+    end
+  end
+
+  context 'parenting' do
+    it 'parents content when assigned' do
+      layout = Component::Layout::Absolute.new
+      Screen.instance.content = layout
+      assert_equal pane, layout.parent
+    end
+
+    it 'parents popups when added' do
+      popup = PopupWindow.new
+      popup.content = ['a']
+      Screen.instance.add_popup(popup)
+      assert_equal pane, popup.parent
+    end
+
+    it 'detaches popup parent when removed' do
+      popup = PopupWindow.new
+      popup.content = ['a']
+      Screen.instance.add_popup(popup)
+      Screen.instance.remove_popup(popup)
+      assert_nil popup.parent
+    end
+  end
+end

--- a/spec/ttyui/screen_spec.rb
+++ b/spec/ttyui/screen_spec.rb
@@ -235,6 +235,27 @@ describe Screen do
       assert !tiled_repainted
     end
 
+    it 'paints popup descendants after tiled descendants so popup contents are not overdrawn' do
+      # Regression: ScreenPane refactor put popups under the pane (depth 1) and
+      # their contents at depth 2. A tiled list at depth 3 would then sort *after*
+      # popup.content and overdraw it, leaving the popup empty until the user
+      # nudged the popup's cursor and triggered a fresh paint.
+      w = add_window
+      popup = PopupWindow.new
+      popup.content = ['option']
+      screen.add_popup(popup)
+      screen.invalidated_clear
+
+      order = []
+      w.content.define_singleton_method(:repaint) { order << :tiled_content }
+      popup.content.define_singleton_method(:repaint) { order << :popup_content }
+      screen.invalidate(w.content)
+      screen.invalidate(popup.content)
+      screen.repaint
+
+      assert_equal %i[tiled_content popup_content], order
+    end
+
     it 'hides the hardware cursor after repaint when no component owns it' do
       w = add_window
       screen.invalidate(w)


### PR DESCRIPTION
Screen is a singleton runtime owner (event loop, lock, terminal IO, invalidation set). All UI now lives under a ScreenPane Component: content, popups stack, and status bar share a single tree root.

Payoffs:
- Screen#focused= collapses the popup-vs-content branches into one uniform path with a single validation: focused.root != @pane.
- Component#attached? becomes root == screen.pane.
- Pane#on_child_removed handles popup focus repair via the standard Component hook, replacing the explicit patch in Screen#remove_popup.
- needs_full_repaint walks one tree (@pane.on_tree) instead of three separate collections.

ScreenPane is intentionally not a Layout: popups overlap content (Z-ordered, full overdraw, no clipping) and key/mouse dispatch follows modal-popup rules rather than Layout's active-child dispatch.

Status bar moves inside Pane so Pane is a complete tree root. Pane#rect= directly triggers layout (rather than relying on on_width_changed) so a pure-height resize re-lays out children.

Forwarders on Screen (content=, popups, add_popup, remove_popup, has_popup?) preserve the public API; no caller changes needed beyond the two list_spec tests that bypassed the setter via instance_variable_set on Screen.